### PR TITLE
Fix `YABM` instance type to `MRB_TT_DATA`

### DIFF
--- a/src/mrb_yabm.c
+++ b/src/mrb_yabm.c
@@ -13,6 +13,7 @@
 #include "mruby/data.h"
 #include "mruby/array.h"
 #include "mruby/string.h"
+#include "mruby/class.h"
 
 #include "mrb_yabm.h"
 
@@ -650,6 +651,7 @@ void mrb_mruby_yabm_gem_init(mrb_state *mrb)
 {
   struct RClass *yabm;
   yabm = mrb_define_class(mrb, "YABM", mrb->object_class);
+  MRB_SET_INSTANCE_TT(yabm, MRB_TT_DATA);
 
   mrb_define_const(mrb, yabm, "MODULE_UNKNOWN", mrb_fixnum_value(MODULE_UNKNOWN));
   mrb_define_const(mrb, yabm, "MODULE_RTL8196C", mrb_fixnum_value(MODULE_RTL8196C));

--- a/src/mrb_yabm_dummy.c
+++ b/src/mrb_yabm_dummy.c
@@ -14,6 +14,7 @@
 #include "mruby/data.h"
 #include "mruby/array.h"
 #include "mruby/string.h"
+#include "mruby/class.h"
 
 #include "mrb_yabm.h"
 
@@ -155,6 +156,7 @@ void mrb_mruby_yabm_gem_init(mrb_state *mrb)
 {
   struct RClass *yabm;
   yabm = mrb_define_class(mrb, "YABM", mrb->object_class);
+  MRB_SET_INSTANCE_TT(yabm, MRB_TT_DATA);
 
   mrb_define_const(mrb, yabm, "MODULE_UNKNOWN", mrb_fixnum_value(MODULE_UNKNOWN));
   mrb_define_const(mrb, yabm, "MODULE_RTL8196C", mrb_fixnum_value(MODULE_RTL8196C));


### PR DESCRIPTION
`YABM#initialize` では `RData` と扱っていますが、先じてクラスの instance type tag を変更しておく必要があります。

`https://github.com/mruby/mruby/issues/5201` の問題とは関係ないと思うので、こっそり PR しておきます。
